### PR TITLE
Add insecure (http) mode to OpenWeather

### DIFF
--- a/OpenWeather.cpp
+++ b/OpenWeather.cpp
@@ -5,6 +5,7 @@
 // This is a beta test version and is subject to change!
 
 // See license.txt in root folder of library
+//Insecure mode by ADAMSIN12
 
 #ifdef ESP8266
   #include <ESP8266WiFi.h>

--- a/OpenWeather.h
+++ b/OpenWeather.h
@@ -5,6 +5,7 @@
 
 // Created by Bodmer 9/4/2020
 // This is a beta test version and is subject to change!
+//Insecure mode added by ADAMSIN12
 
 // See license.txt in root folder of library
 
@@ -28,10 +29,12 @@ class OW_Weather: public JsonListener {
     // Sketch calls this forecast request, it returns true if no parse errors encountered
     bool getForecast(OW_current *current, OW_hourly *hourly, OW_daily  *daily,
                      String api_key, String latitude, String longitude,
-                     String units, String language, bool secure);
+                     String units, String language, bool secure = true);
 
     // Called by library (or user sketch), sends a GET request to a https (secure) url
     bool parseRequest(String url); // and parses response, returns true if no parse errors
+
+    bool parseRequestInsecure(String url); 
 
     void partialDataSet(bool partialSet);
 

--- a/OpenWeather.h
+++ b/OpenWeather.h
@@ -28,7 +28,7 @@ class OW_Weather: public JsonListener {
     // Sketch calls this forecast request, it returns true if no parse errors encountered
     bool getForecast(OW_current *current, OW_hourly *hourly, OW_daily  *daily,
                      String api_key, String latitude, String longitude,
-                     String units, String language);
+                     String units, String language, bool secure);
 
     // Called by library (or user sketch), sends a GET request to a https (secure) url
     bool parseRequest(String url); // and parses response, returns true if no parse errors
@@ -99,6 +99,8 @@ class OW_Weather: public JsonListener {
     String   arrayPath;     // Path to name:value pair e.g.  "daily/data"
     uint16_t arrayIndex;    // Array index e.g. 5 for day 5 forecast, qualify with arrayPath
     uint16_t arrayLevel;    // Array level
+bool Secure;
+bool secure;
 
 };
 

--- a/examples/My_OpenWeather_Test/My_OpenWeather_Test.ino
+++ b/examples/My_OpenWeather_Test/My_OpenWeather_Test.ino
@@ -87,6 +87,10 @@ void printCurrentWeather()
 
   Serial.print("\nRequesting weather information from OpenWeather... ");
 
+
+  //If you have problems with stability, use Insecure mode by adding a false parameter behind language or simply delete the slashes on the line below and delete the current getForecast
+  //ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, false);
+  
   ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language);
 
   Serial.println("Weather from Open Weather\n");


### PR DESCRIPTION


I was working on a simple project and tried to get the weather. The problem was, this caused a stack overflow error, because of a core flaw in the BearSSL (my best understanding is that it times out and fills the stack, the reason it crashed is that I had little stack available) So I decided to modify the library to pass another parameter in the function called secure. When it is set to false, the client is not declared with BearSSL, but just a standard WIFIClient. When it is true, there is no modification to the original code.

Secure GET
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, true);

Insecure and lighter GET
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, false)

New parameter:
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, -->bool<--)